### PR TITLE
fix: harden online lyric fetching and cache handling

### DIFF
--- a/app/src/main/java/com/hchen/superlyric/HookEntrance.java
+++ b/app/src/main/java/com/hchen/superlyric/HookEntrance.java
@@ -42,6 +42,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Hook 入口
@@ -77,6 +79,10 @@ public final class HookEntrance extends ModuleEntrance {
     }
 
     private final HashMap<String, AbsModule> modules = new HashMap<>();
+    private final HashMap<String, ClassLoader> moduleClassLoaders = new HashMap<>();
+    private final ExecutorService cacheMigrationExecutor = Executors.newSingleThreadExecutor();
+    @Nullable
+    private Context lastApplicationContext;
 
     @Override
     public void handlePackageReady(@NonNull PackageReadyParam param) {
@@ -97,9 +103,15 @@ public final class HookEntrance extends ModuleEntrance {
                 );
 
 
-                if (modules.containsKey(param.getPackageName())) {
+                ClassLoader previousLoader = moduleClassLoaders.get(param.getPackageName());
+                if (modules.containsKey(param.getPackageName()) && previousLoader == param.getClassLoader()) {
                     AbsModule module = Objects.requireNonNull(modules.get(param.getPackageName()));
                     module.handlePackageReady(param);
+                    return;
+                }
+                if (previousLoader != null && previousLoader != param.getClassLoader()) {
+                    AndroidLog.logE(TAG, "Ignore package reload with a different ClassLoader: "
+                        + param.getPackageName());
                     return;
                 }
 
@@ -112,6 +124,7 @@ public final class HookEntrance extends ModuleEntrance {
 
                         module.handlePackageReady(param);
                         modules.put(param.getPackageName(), module);
+                        moduleClassLoaders.put(param.getPackageName(), param.getClassLoader());
                     } catch (IllegalAccessException | InstantiationException |
                              InvocationTargetException | NoSuchMethodException |
                              ClassNotFoundException e) {
@@ -129,12 +142,15 @@ public final class HookEntrance extends ModuleEntrance {
         AndroidLog.logD(TAG, "handleApplicationCreated: " + context);
         super.handleApplicationCreated(context);
 
-        clearLyricCacheOnFormatUpgrade(context);
+        Context appContext = context.getApplicationContext();
+        if (lastApplicationContext == appContext) return;
+        cacheMigrationExecutor.execute(() -> clearLyricCacheOnFormatUpgrade(appContext));
         for (AbsModule module : modules.values()) {
             if (module != null) {
                 module.handleApplicationCreated(context);
             }
         }
+        lastApplicationContext = appContext;
     }
 
     /**
@@ -146,9 +162,17 @@ public final class HookEntrance extends ModuleEntrance {
             int lastCleared = PrefsTool.prefs(context).getInt("super_lyric_cache_format", 0);
             int current = LyricCacheStore.cacheVersion();
             if (lastCleared == current) return;
-            PrefsTool.prefs(context).edit().putInt("super_lyric_cache_format", current).apply();
-            for (String provider : new String[]{"Netease", "Hihonor", "Spotify"}) {
-                LyricCacheStore.clearProviderCache(context, provider);
+            if (!LyricCacheStore.clearOnlineProviderCaches(context)) {
+                AndroidLog.logE(TAG, "Lyric cache format migration incomplete; retry on next startup");
+                return;
+            }
+            boolean committed = PrefsTool.prefs(context)
+                .edit()
+                .putInt("super_lyric_cache_format", current)
+                .commit();
+            if (!committed) {
+                AndroidLog.logE(TAG, "Failed to persist lyric cache format migration; retry on next startup");
+                return;
             }
             AndroidLog.logD(TAG, "Lyric cache cleared on format upgrade: " + lastCleared + " -> " + current);
         } catch (Throwable t) {

--- a/app/src/main/java/com/hchen/superlyric/hook/music/online/Spotify.java
+++ b/app/src/main/java/com/hchen/superlyric/hook/music/online/Spotify.java
@@ -37,12 +37,15 @@ import com.hchen.superlyric.utils.LyricCacheStore;
 import com.hchen.superlyricapi.SuperLyricData;
 import com.hchen.superlyricapi.SuperLyricLine;
 
+import java.io.IOException;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.github.libxposed.api.XposedModuleInterface;
@@ -64,7 +67,9 @@ public final class Spotify extends AbsPublisher {
     private static final long LOOP_INTERVAL_MS = 42L;
 
     private Context mAppContext;
+    private HandlerThread mLyricThread;
     private Handler mLyricHandler;
+    private boolean mHooksInitialized;
 
     // 播放状态（setPlaybackState 写入，轮询线程读取）：
     // 单一不可变快照整体发布，避免 state/position/speed/锚点多次 volatile 写入的中间态
@@ -74,16 +79,38 @@ public final class Spotify extends AbsPublisher {
     // song + lyric + lastShownIndex 原子可见；行推进 / 歌词写入均以 compareAndSet
     // 原子替换，快速切歌时异步拉取与切歌不产生歌词与元数据错配、无上一首残留
     private final AtomicReference<TrackSnapshot> mTrackRef = new AtomicReference<>();
+    private final AtomicLong mTrackGeneration = new AtomicLong();
 
     // 轮询推进：mIsRunning 防重入；mLoopToken 使重启后的旧轮询链立即失效，
     // 避免 stopLoop→startLoop 时序下出现双链并行
     private volatile boolean mIsRunning = false;
     private volatile long mLoopToken = 0L;
+    private static final class HeaderWait {
+        @NonNull
+        final String trackId;
+        final long headerGeneration;
+        final long trackGeneration;
 
-    // 异步拉取（缓存线程池：快速切歌时新请求不被慢的旧请求阻塞，
-    // 过期结果由 applyLyrics 的 trackId 校验丢弃）
-    private final ExecutorService mDownloadExecutor = Executors.newCachedThreadPool();
+        HeaderWait(@NonNull String trackId, long headerGeneration, long trackGeneration) {
+            this.trackId = trackId;
+            this.headerGeneration = headerGeneration;
+            this.trackGeneration = trackGeneration;
+        }
+    }
+
+    private final AtomicReference<HeaderWait> mHeaderWait = new AtomicReference<>();
+
+    private final ThreadPoolExecutor mDownloadExecutor = new ThreadPoolExecutor(
+        2, 2, 0L, TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<>(4),
+        new ThreadPoolExecutor.AbortPolicy()
+    );
     private final Set<String> mDownloadingIds = ConcurrentHashMap.newKeySet();
+    private static final int MAX_FETCH_RETRIES = 3;
+    private static final int MAX_AUTH_REFRESHES = 2;
+    private final ConcurrentHashMap<String, Integer> mRetryCounts = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Integer> mAuthRefreshCounts = new ConcurrentHashMap<>();
+
 
     /** 歌曲上下文快照：音轨标识 + 标题/歌手，与歌词配对发布的元数据来源。 */
     private static final class SongInfo {
@@ -134,13 +161,15 @@ public final class Spotify extends AbsPublisher {
 
     /** 歌曲上下文快照：当前歌曲 + 歌词（可为空）+ 已展示行索引，整体原子替换。 */
     private static final class TrackSnapshot {
+        final long generation;
         @NonNull
         final SongInfo song;
         @Nullable
         final LyricData lyric;
         final int lastShownIndex;
 
-        TrackSnapshot(@NonNull SongInfo song, @Nullable LyricData lyric, int lastShownIndex) {
+        TrackSnapshot(long generation, @NonNull SongInfo song, @Nullable LyricData lyric, int lastShownIndex) {
+            this.generation = generation;
             this.song = song;
             this.lyric = lyric;
             this.lastShownIndex = lastShownIndex;
@@ -148,26 +177,30 @@ public final class Spotify extends AbsPublisher {
 
         @NonNull
         TrackSnapshot withLyric(@NonNull LyricData newLyric) {
-            return new TrackSnapshot(song, newLyric, -1);
+            return new TrackSnapshot(generation, song, newLyric, -1);
         }
 
         @NonNull
         TrackSnapshot withShownIndex(int index) {
-            return new TrackSnapshot(song, lyric, index);
+            return new TrackSnapshot(generation, song, lyric, index);
         }
     }
 
     @Override
-    protected void onPackageReady(@NonNull XposedModuleInterface.PackageReadyParam param) {
+    protected synchronized void onPackageReady(@NonNull XposedModuleInterface.PackageReadyParam param) {
         super.onPackageReady(param);
-        // 轮询线程
-        HandlerThread lyricThread = new HandlerThread("SpotifyLyricThread");
-        lyricThread.start();
-        mLyricHandler = new Handler(lyricThread.getLooper());
+        if (mHooksInitialized) {
+            logD(TAG, "Spotify hooks already initialized for " + param.getPackageName());
+            return;
+        }
+        mLyricThread = new HandlerThread("SpotifyLyricThread");
+        mLyricThread.start();
+        mLyricHandler = new Handler(mLyricThread.getLooper());
 
         hookPlaybackState();
         hookMetadata();
         hookSessionHeaders();
+        mHooksInitialized = true;
 
         logI(TAG, "Spotify hooks loaded (package: " + param.getPackageName() + ")");
     }
@@ -244,6 +277,9 @@ public final class Spotify extends AbsPublisher {
         if (id == null) {
             // 广告 / 无法解析音轨标识 → sendStop 清空（Apple 范式）
             logD(TAG, "setMetadata: no valid track id, treat as ad/unknown, sendStop");
+            SpotifyLyricAnalysis.cancelExcept(null);
+            mHeaderWait.set(null);
+            mTrackRef.set(null);
             sendStop();
             stopLoop();
             return;
@@ -254,20 +290,23 @@ public final class Spotify extends AbsPublisher {
             return;
         }
 
+        SpotifyLyricAnalysis.cancelExcept(id);
         // 切歌：立即清空旧歌词与显示，避免残留上一首
         sendStop();
         stopLoop();
 
         String title = metadata.getString(MediaMetadata.METADATA_KEY_TITLE);
         String artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST);
+        long generation = mTrackGeneration.incrementAndGet();
         mTrackRef.set(new TrackSnapshot(
+            generation,
             new SongInfo(id, title != null ? title : "", artist != null ? artist : ""),
             null,
             -1
         ));
-        logD(TAG, "Track changed: id=" + id + ", title=" + title + ", artist=" + artist);
+        logD(TAG, "Track changed: id=" + id);
 
-        fetchLyricsForTrack(id);
+        fetchLyricsForTrack(id, generation);
     }
 
     /**
@@ -286,71 +325,132 @@ public final class Spotify extends AbsPublisher {
 
     // ------------------------------ 拉取与缓存 ------------------------------
 
-    private void fetchLyricsForTrack(@NonNull String id) {
-        // 独立命名空间（宿主私有缓存，与 LyricProvider 同方案）：
-        // cacheDir/SuperLyric/lyric/Spotify/{locale}/{id}.json，locale 目录与 LyricProvider 一致
-        String cacheKey = LyricCacheStore.currentLocaleTag() + "/" + id;
-
-        byte[] cached = LyricCacheStore.getBytes(mAppContext, "Spotify", cacheKey);
-        if (cached != null) {
-            List<SpotifyLine> lines = parseOrNull(cached);
-            if (lines != null) {
-                logD(TAG, "Lyric cache hit for " + id + ", no network request");
-                applyLyrics(id, lines);
-                return;
-            }
-            // 坏缓存：删除并回退网络，避免被永久毒化
-            logW(TAG, "Cached lyric unparseable for " + id + ", evict and refetch");
-            LyricCacheStore.delete(mAppContext, "Spotify", cacheKey);
-        }
-
-        if (!mDownloadingIds.add(id)) {
-            logD(TAG, "Lyric already downloading for " + id);
-            return;
-        }
-
-        mDownloadExecutor.execute(() -> {
-            try {
-                byte[] raw = SpotifyLyricAnalysis.fetchLyric(id);
-                logD(TAG, "Lyric fetched for " + id + ", bytes length=" + raw.length);
-                List<SpotifyLine> lines = parseOrNull(raw);
-                if (lines == null) {
-                    // 非法响应不入缓存，保持空白，避免坏数据持久化
-                    logW(TAG, "Lyric response unparseable for " + id + ", keep blank");
-                    return;
-                }
-                LyricCacheStore.put(mAppContext, "Spotify", cacheKey, raw);
-                logD(TAG, "Lyric cache written: Spotify/" + cacheKey + ".json");
-                applyLyrics(id, lines);
-            } catch (SpotifyLyricAnalysis.NoFoundLyricException e) {
-                logD(TAG, "No lyric found (404) for " + id + ", keep blank");
-            } catch (Exception e) {
-                logE(TAG, "Failed to fetch lyric for " + id, e);
-            } finally {
-                mDownloadingIds.remove(id);
-            }
-        });
+    private static String taskKey(@NonNull String id, long generation) {
+        return id + "#" + generation;
     }
 
-    /**
-     * 解析原始响应（JSON / protobuf 自动分流），无歌词或解析失败返回 {@code null}。
-     */
-    @Nullable
-    private List<SpotifyLine> parseOrNull(byte[] raw) {
-        List<SpotifyLine> lines = SpotifyLyricAnalysis.parseLyrics(raw);
-        return (lines == null || lines.isEmpty()) ? null : lines;
+    private void fetchLyricsForTrack(@NonNull String id, long generation) {
+        String taskKey = taskKey(id, generation);
+        if (!mDownloadingIds.add(taskKey)) {
+            logD(TAG, "Lyric already loading for " + id);
+            return;
+        }
+        try {
+            mDownloadExecutor.execute(() -> loadLyricsForTrack(id, generation, taskKey));
+        } catch (RejectedExecutionException e) {
+            mDownloadingIds.remove(taskKey);
+            scheduleFetchRetry(id, generation);
+        }
+    }
+
+    private void loadLyricsForTrack(@NonNull String id, long generation, @NonNull String taskKey) {
+        String cacheKey = LyricCacheStore.currentLocaleTag() + "/" + id;
+        try {
+            if (!isCurrentTrack(id, generation)) return;
+            byte[] cached = LyricCacheStore.getBytes(mAppContext, "Spotify", cacheKey);
+            if (cached != null) {
+                SpotifyLyricAnalysis.ParseResult result = SpotifyLyricAnalysis.parseResult(cached);
+                if (result.type == SpotifyLyricAnalysis.ParseType.READY && result.lines != null) {
+                    applyLyrics(id, generation, result.lines);
+                    return;
+                }
+                LyricCacheStore.delete(mAppContext, "Spotify", cacheKey);
+            }
+
+            SpotifyLyricAnalysis.HeaderSnapshot headers = SpotifyLyricAnalysis.currentHeaders();
+            if (headers == null) {
+                waitForHeaders(id, 0L, generation);
+                return;
+            }
+            byte[] raw = SpotifyLyricAnalysis.fetchLyric(id, headers);
+            SpotifyLyricAnalysis.ParseResult result = SpotifyLyricAnalysis.parseResult(raw);
+            if (result.type == SpotifyLyricAnalysis.ParseType.MALFORMED) {
+                scheduleFetchRetry(id, generation);
+                return;
+            }
+            if (result.type != SpotifyLyricAnalysis.ParseType.READY || result.lines == null) {
+                logW(TAG, "Lyric response not usable for " + id + ", type=" + result.type);
+                return;
+            }
+            if (!isCurrentTrack(id, generation)) return;
+            LyricCacheStore.put(mAppContext, "Spotify", cacheKey, raw);
+            applyLyrics(id, generation, result.lines);
+        } catch (SpotifyLyricAnalysis.AuthenticationException e) {
+            String retryKey = taskKey(id, generation);
+            int refreshes = mAuthRefreshCounts.merge(retryKey, 1, Integer::sum);
+            if (refreshes <= MAX_AUTH_REFRESHES) {
+                waitForHeaders(id, e.generation, generation);
+            } else {
+                mAuthRefreshCounts.remove(retryKey);
+                logW(TAG, "Spotify authentication refresh exhausted for " + id);
+            }
+        } catch (SpotifyLyricAnalysis.NoFoundLyricException e) {
+            logD(TAG, "No lyric found (404) for " + id);
+        } catch (SpotifyLyricAnalysis.OversizeException e) {
+            logW(TAG, "Spotify lyric response exceeds budget for " + id);
+        } catch (SpotifyLyricAnalysis.HttpStatusException e) {
+            if (e.retryable) scheduleFetchRetry(id, generation);
+            else logW(TAG, "Non-retryable Spotify HTTP " + e.code + " for " + id);
+        } catch (IOException e) {
+            scheduleFetchRetry(id, generation);
+        } catch (Exception e) {
+            if (isCurrentTrack(id, generation)) logE(TAG, "Failed to fetch lyric for " + id, e);
+        } finally {
+            mDownloadingIds.remove(taskKey);
+            resumeHeaderWaitIfReady();
+        }
+    }
+
+    private void scheduleFetchRetry(@NonNull String id, long generation) {
+        if (!isCurrentTrack(id, generation)) return;
+        String retryKey = taskKey(id, generation);
+        int attempt = mRetryCounts.merge(retryKey, 1, Integer::sum);
+        if (attempt > MAX_FETCH_RETRIES) {
+            mRetryCounts.remove(retryKey);
+            logW(TAG, "Spotify lyric retry exhausted for " + id);
+            return;
+        }
+        long delay = Math.min(5000L << (attempt - 1), 30000L);
+        mLyricHandler.postDelayed(() -> {
+            if (isCurrentTrack(id, generation)) {
+                fetchLyricsForTrack(id, generation);
+            } else {
+                mRetryCounts.remove(retryKey);
+                mAuthRefreshCounts.remove(retryKey);
+            }
+        }, delay);
+    }
+
+    private boolean isCurrentTrack(@NonNull String id, long generation) {
+        TrackSnapshot current = mTrackRef.get();
+        return current != null && current.generation == generation && id.equals(current.song.trackId);
+    }
+
+    private void waitForHeaders(@NonNull String id, long headerGeneration, long trackGeneration) {
+        if (isCurrentTrack(id, trackGeneration)) {
+            mHeaderWait.set(new HeaderWait(id, headerGeneration, trackGeneration));
+            resumeHeaderWaitIfReady();
+        }
+    }
+
+    private void resumeHeaderWaitIfReady() {
+        HeaderWait wait = mHeaderWait.get();
+        SpotifyLyricAnalysis.HeaderSnapshot headers = SpotifyLyricAnalysis.currentHeaders();
+        if (wait == null || headers == null || headers.generation <= wait.headerGeneration) return;
+        String taskKey = taskKey(wait.trackId, wait.trackGeneration);
+        if (!isCurrentTrack(wait.trackId, wait.trackGeneration) || mDownloadingIds.contains(taskKey)) return;
+        if (mHeaderWait.compareAndSet(wait, null)) fetchLyricsForTrack(wait.trackId, wait.trackGeneration);
     }
 
     /**
      * 原子写入歌词快照并启动行推进；
      * 仅当前音轨与请求音轨一致时才生效，过期结果直接丢弃。
      */
-    private void applyLyrics(@NonNull String id, @NonNull List<SpotifyLine> lines) {
-        // 竞态防护：异步拉取完成时校验当前音轨（与当前歌曲快照比对）
+    private void applyLyrics(@NonNull String id, long generation,
+                             @NonNull List<SpotifyLine> lines) {
         TrackSnapshot current = mTrackRef.get();
-        if (current == null || !id.equals(current.song.trackId)) {
-            logD(TAG, "Stale lyric response for " + id
-                + ", current=" + (current == null ? "null" : current.song.trackId) + ", discard");
+        if (current == null || current.generation != generation || !id.equals(current.song.trackId)) {
+            logD(TAG, "Stale lyric response for " + id + ", discard");
             return;
         }
 
@@ -359,7 +459,10 @@ public final class Spotify extends AbsPublisher {
             logD(TAG, "Track changed while applying lyric for " + id + ", discard");
             return;
         }
-        logD(TAG, "Lyrics ready for " + id + ", lines=" + lines.size() + ", first=" + lines.get(0).text
+        String completedKey = taskKey(id, generation);
+        mRetryCounts.remove(completedKey);
+        mAuthRefreshCounts.remove(completedKey);
+        logD(TAG, "Lyrics ready for " + id + ", lines=" + lines.size()
             + ", firstWords=" + (lines.get(0).words == null ? 0 : lines.get(0).words.length));
 
         if (mPlayback.state == PlaybackState.STATE_PLAYING) {
@@ -420,18 +523,33 @@ public final class Spotify extends AbsPublisher {
      * 位置插值：上次采样位置 + 速度 × 流逝时间。
      */
     private static long estimatePosition(@NonNull PlaybackSnapshot playback, long now) {
+        long base = Math.max(0L, playback.position);
+        if (!Float.isFinite(playback.speed) || playback.speed < 0f || now <= playback.anchorTime) return base;
         long elapsed = now - playback.anchorTime;
-        return playback.position + (long) (elapsed * playback.speed);
+        double delta = elapsed * (double) playback.speed;
+        if (!Double.isFinite(delta) || delta >= Long.MAX_VALUE) return Long.MAX_VALUE;
+        try {
+            return Math.max(0L, Math.addExact(base, (long) delta));
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
     }
 
     /**
      * 顺序查找 startTime ≤ 位置 < endTime 的行。
      */
     private static int findLineIndex(@NonNull List<SpotifyLine> lines, long position) {
-        for (int i = 0; i < lines.size(); i++) {
-            SpotifyLine line = lines.get(i);
-            if (position >= line.startTimeMs && position < line.endTimeMs) {
-                return i;
+        int low = 0;
+        int high = lines.size() - 1;
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            SpotifyLine line = lines.get(mid);
+            if (position < line.startTimeMs) {
+                high = mid - 1;
+            } else if (position >= line.endTimeMs) {
+                low = mid + 1;
+            } else {
+                return mid;
             }
         }
         return -1;
@@ -446,7 +564,7 @@ public final class Spotify extends AbsPublisher {
             data.setTranslation(new SuperLyricLine(line.transliteratedWords));
         }
         sendLyric(data);
-        logD(TAG, "sendLyric: [" + song.title + " - " + song.artist + "] " + line.text);
+        logD(TAG, "sendLyric: track=" + song.trackId + ", start=" + line.startTimeMs);
     }
 
     // ------------------------------ 会话头捕获 ------------------------------
@@ -472,15 +590,7 @@ public final class Spotify extends AbsPublisher {
     }
 
     private void captureNamesAndValues(@NonNull String[] namesAndValues) {
-        for (int i = 0; i + 1 < namesAndValues.length; i += 2) {
-            captureHeader(namesAndValues[i], namesAndValues[i + 1]);
-        }
-    }
-
-    private void captureHeader(@NonNull String name, @NonNull String value) {
-        String lower = name.toLowerCase(Locale.ENGLISH);
-        if (SpotifyLyricAnalysis.isKeyRequired(lower)) {
-            SpotifyLyricAnalysis.setHeader(lower, value);
-        }
+        SpotifyLyricAnalysis.HeaderSnapshot headers = SpotifyLyricAnalysis.updateHeaders(namesAndValues);
+        if (headers != null) resumeHeaderWaitIfReady();
     }
 }

--- a/app/src/main/java/com/hchen/superlyric/hook/music/online/netease/NeteaseLyricAnalysis.java
+++ b/app/src/main/java/com/hchen/superlyric/hook/music/online/netease/NeteaseLyricAnalysis.java
@@ -28,8 +28,11 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.hchen.hooktool.log.XposedLog;
 import com.hchen.superlyricapi.SuperLyricWord;
+import com.hchen.superlyric.utils.LyricCacheStore;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
@@ -41,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -49,6 +53,7 @@ import java.util.stream.Collectors;
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
+import okhttp3.Call;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -84,9 +89,12 @@ public final class NeteaseLyricAnalysis {
 
     private static final Gson gson = new Gson();
 
+    private static final Map<Long, Call> activeCalls = new ConcurrentHashMap<>();
+
     private static final OkHttpClient client = new OkHttpClient.Builder()
         .connectTimeout(15, TimeUnit.SECONDS)
         .readTimeout(15, TimeUnit.SECONDS)
+        .callTimeout(30, TimeUnit.SECONDS)
         .addInterceptor(BrotliInterceptor.INSTANCE)
         .build();
 
@@ -151,6 +159,23 @@ public final class NeteaseLyricAnalysis {
 
     // ------------------------------ 网络拉取 ------------------------------
 
+    public static final class OversizeException extends IOException {
+        OversizeException(int maxBytes) {
+            super("Netease lyric response exceeds " + maxBytes + " bytes");
+        }
+    }
+
+    public static final class HttpStatusException extends IOException {
+        public final int code;
+        public final boolean retryable;
+
+        HttpStatusException(int code) {
+            super("Netease HTTP " + code);
+            this.code = code;
+            this.retryable = code == 429 || code >= 500;
+        }
+    }
+
     /**
      * 拉取指定歌曲的歌词接口原始 JSON。
      *
@@ -172,21 +197,55 @@ public final class NeteaseLyricAnalysis {
             .post(body)
             .build();
 
-        try (Response response = client.newCall(request).execute()) {
-            String bodyStr = response.body().string();
+        Call call = client.newCall(request);
+        Call previous = activeCalls.put(id, call);
+        if (previous != null) previous.cancel();
+        try (Response response = call.execute()) {
             if (!response.isSuccessful()) {
-                throw new IOException("HTTP error code: " + response.code() + ", msg: " + response.message());
+                throw new HttpStatusException(response.code());
             }
+            if (response.body() == null) {
+                throw new IOException("Empty HTTP response body for " + id);
+            }
+            long contentLength = response.body().contentLength();
+            if (contentLength > LyricCacheStore.MAX_PAYLOAD_BYTES) {
+                throw new OversizeException(LyricCacheStore.MAX_PAYLOAD_BYTES);
+            }
+            byte[] responseBytes = readLimited(response.body().byteStream(), LyricCacheStore.MAX_PAYLOAD_BYTES);
+            String bodyStr = new String(responseBytes, StandardCharsets.UTF_8);
 
             try {
                 gson.fromJson(bodyStr, JsonObject.class);
             } catch (JsonSyntaxException e) {
-                throw new IOException("Invalid JSON response for " + id + ": " + bodyStr, e);
+                throw new IOException("Invalid JSON response for " + id + ", bytes="
+                    + bodyStr.getBytes(StandardCharsets.UTF_8).length, e);
             }
             XposedLog.logD(TAG, "eapi lyric response: httpCode=" + response.code()
                 + ", jsonLength=" + bodyStr.length() + ", brotli decode ok");
             return bodyStr;
+        } finally {
+            activeCalls.remove(id, call);
         }
+    }
+
+    public static void cancelExcept(long currentId) {
+        activeCalls.forEach((id, call) -> {
+            if (id != currentId) call.cancel();
+        });
+    }
+
+    @NonNull
+    private static byte[] readLimited(@NonNull InputStream input, int maxBytes) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream(Math.min(maxBytes, 8192));
+        byte[] buffer = new byte[8192];
+        int total = 0;
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            if (read > maxBytes - total) throw new OversizeException(maxBytes);
+            output.write(buffer, 0, read);
+            total += read;
+        }
+        return output.toByteArray();
     }
 
     @NonNull
@@ -205,6 +264,14 @@ public final class NeteaseLyricAnalysis {
 
     // ------------------------------ 解析与数据模型 ------------------------------
 
+    public enum ResultType {
+        READY,
+        EMPTY,
+        PURE_MUSIC,
+        MALFORMED,
+        API_ERROR
+    }
+
     /**
      * 解析接口原始 JSON 为行级数据模型：
      * <ul>
@@ -222,21 +289,25 @@ public final class NeteaseLyricAnalysis {
         try {
             LyricResponse response = gson.fromJson(json, LyricResponse.class);
             if (response == null) {
-                return new LyricData(0, false, null);
+                return new LyricData(ResultType.MALFORMED, 0, false, null);
             }
             if (response.code != 200) {
-                XposedLog.logD(TAG, "eapi lyric code=" + response.code + ", treat as no lyric");
-                return new LyricData(response.code, response.pureMusic, null);
+                XposedLog.logD(TAG, "eapi lyric code=" + response.code + ", treat as API error");
+                return new LyricData(ResultType.API_ERROR, response.code, response.pureMusic, null);
+            }
+            if (response.pureMusic) {
+                return new LyricData(ResultType.PURE_MUSIC, response.code, true, null);
             }
             List<LyricLineData> lines = buildLines(response);
             return new LyricData(
+                lines == null || lines.isEmpty() ? ResultType.EMPTY : ResultType.READY,
                 response.code,
-                response.pureMusic,
+                false,
                 lines != null ? Collections.unmodifiableList(lines) : null
             );
         } catch (JsonSyntaxException e) {
             XposedLog.logE(TAG, "Failed to parse netease lyric json", e);
-            return new LyricData(0, false, null);
+            return new LyricData(ResultType.MALFORMED, 0, false, null);
         }
     }
 
@@ -314,21 +385,32 @@ public final class NeteaseLyricAnalysis {
             Matcher headerMatcher = YRC_LINE_HEADER_REGEX.matcher(line);
             if (!headerMatcher.find()) continue;
 
-            long lineStart = parseLong(headerMatcher.group(1));
-            long lineDuration = parseLong(headerMatcher.group(2));
-            long lineEnd = lineStart + lineDuration;
+            long lineStart = parseNonNegativeLong(headerMatcher.group(1));
+            long lineDuration = parseNonNegativeLong(headerMatcher.group(2));
+            long lineEnd = checkedEnd(lineStart, lineDuration);
+            if (lineStart < 0L || lineDuration < 0L || lineEnd <= lineStart) continue;
 
             List<ParsedWord> words = new ArrayList<>();
             String contentPart = line.substring(headerMatcher.end());
             Matcher wordMatcher = YRC_SYLLABLE_REGEX.matcher(contentPart);
             while (wordMatcher.find()) {
-                long start = parseLong(wordMatcher.group(1));
-                long duration = parseLong(wordMatcher.group(2));
+                long start = parseNonNegativeLong(wordMatcher.group(1));
+                long duration = parseNonNegativeLong(wordMatcher.group(2));
+                long end = checkedEnd(start, duration);
                 String text = wordMatcher.group(3);
-                if (text == null || text.isEmpty()) continue;
-                words.add(new ParsedWord(start, start + duration, text));
+                if (start < 0L || duration < 0L || end <= start || text == null || text.isEmpty()) continue;
+                words.add(new ParsedWord(start, end, text));
             }
             words.sort(Comparator.comparingLong(word -> word.begin));
+            boolean validWords = true;
+            long previousEnd = lineStart;
+            for (ParsedWord word : words) {
+                if (word.begin < previousEnd || word.end > lineEnd || word.end <= word.begin) {
+                    validWords = false;
+                    break;
+                }
+                previousEnd = word.end;
+            }
 
             StringBuilder textBuilder = new StringBuilder();
             for (ParsedWord word : words) {
@@ -337,7 +419,8 @@ public final class NeteaseLyricAnalysis {
             String text = textBuilder.toString();
             if (text.isBlank()) continue;
 
-            entries.add(new ParsedLine(lineStart, lineEnd, text, words));
+            entries.add(new ParsedLine(lineStart, lineEnd, text,
+                validWords ? words : Collections.emptyList()));
         }
 
         entries.sort(Comparator.comparingLong(entry -> entry.begin));
@@ -364,7 +447,8 @@ public final class NeteaseLyricAnalysis {
                 int lastTagEnd = 0;
                 while (tagMatcher.find()) {
                     if (tagMatcher.start() != lastTagEnd) break;
-                    times.add(toMs(tagMatcher.group(1), tagMatcher.group(2), tagMatcher.group(3)));
+                    long time = toMs(tagMatcher.group(1), tagMatcher.group(2), tagMatcher.group(3));
+                    if (time >= 0L) times.add(time);
                     lastTagEnd = tagMatcher.end();
                 }
                 String content = trimmed.substring(lastTagEnd).trim();
@@ -395,18 +479,26 @@ public final class NeteaseLyricAnalysis {
         List<ParsedLine> finalized = new ArrayList<>(entries.size());
         for (int i = 0; i < entries.size(); i++) {
             ParsedLine current = entries.get(i);
-            long end = i + 1 < entries.size() ? entries.get(i + 1).begin : current.begin + 5000L;
+            long fallbackEnd = safeAdd(current.begin, 5000L);
+            long end = i + 1 < entries.size() ? entries.get(i + 1).begin : fallbackEnd;
+            if (end <= current.begin) continue;
             finalized.add(new ParsedLine(current.begin, end, current.text, current.words));
         }
 
-        long offset = parseLong(meta.get("offset"));
+        String offsetValue = meta.get("offset");
+        long offset = offsetValue == null ? 0L : parseLongOrDefault(offsetValue, Long.MIN_VALUE);
+        if (offset == Long.MIN_VALUE) return Collections.emptyList();
         if (offset == 0L) return finalized;
 
         List<ParsedLine> adjusted = new ArrayList<>(finalized.size());
         for (ParsedLine line : finalized) {
-            long newBegin = Math.max(0L, line.begin + offset);
-            long newEnd = newBegin + (line.end - line.begin);
-            adjusted.add(new ParsedLine(newBegin, newEnd, line.text, line.words));
+            long shiftedBegin = safeAdd(line.begin, offset);
+            long shiftedEnd = safeAdd(line.end, offset);
+            long newBegin = Math.max(0L, shiftedBegin);
+            long newEnd = Math.max(0L, shiftedEnd);
+            if (newEnd > newBegin) {
+                adjusted.add(new ParsedLine(newBegin, newEnd, line.text, line.words));
+            }
         }
         return adjusted;
     }
@@ -470,33 +562,68 @@ public final class NeteaseLyricAnalysis {
         return result;
     }
 
-    private static long parseLong(@Nullable String value) {
-        if (value == null) return 0L;
+    private static long parseNonNegativeLong(@Nullable String value) {
+        long parsed = parseLongOrDefault(value, -1L);
+        return parsed >= 0L ? parsed : -1L;
+    }
+
+    private static long parseLongOrDefault(@Nullable String value, long fallback) {
+        if (value == null) return fallback;
         try {
             return Long.parseLong(value);
         } catch (NumberFormatException e) {
-            return 0L;
+            return fallback;
+        }
+    }
+
+    private static long checkedEnd(long start, long duration) {
+        if (start < 0L || duration <= 0L || duration > Long.MAX_VALUE - start) return -1L;
+        return start + duration;
+    }
+
+    private static long safeAdd(long left, long right) {
+        try {
+            return Math.addExact(left, right);
+        } catch (ArithmeticException e) {
+            return right >= 0L ? Long.MAX_VALUE : Long.MIN_VALUE;
+        }
+    }
+
+    private static long safeMultiply(long left, long right) {
+        try {
+            return Math.multiplyExact(left, right);
+        } catch (ArithmeticException e) {
+            return -1L;
         }
     }
 
     private static long toMs(@Nullable String minute, @Nullable String second, @Nullable String fraction) {
+        long minuteValue = parseNonNegativeLong(minute);
+        long secondValue = parseNonNegativeLong(second);
+        if (minuteValue < 0L || secondValue < 0L || secondValue >= 60L) return -1L;
+
         long ms = 0L;
         if (fraction != null) {
+            long fractionValue = parseNonNegativeLong(fraction);
+            if (fractionValue < 0L) return -1L;
             switch (fraction.length()) {
                 case 1:
-                    ms = parseLong(fraction) * 100L;
+                    ms = fractionValue * 100L;
                     break;
                 case 2:
-                    ms = parseLong(fraction) * 10L;
+                    ms = fractionValue * 10L;
                     break;
                 case 3:
-                    ms = parseLong(fraction);
+                    ms = fractionValue;
                     break;
                 default:
-                    break;
+                    return -1L;
             }
         }
-        return parseLong(minute) * 60000L + parseLong(second) * 1000L + ms;
+        long minuteMs = safeMultiply(minuteValue, 60000L);
+        long secondMs = safeMultiply(secondValue, 1000L);
+        if (minuteMs < 0L || secondMs < 0L) return -1L;
+        return safeAdd(safeAdd(minuteMs, secondMs), ms);
     }
 
     // ------------------------------ 数据模型 ------------------------------
@@ -551,19 +678,23 @@ public final class NeteaseLyricAnalysis {
      * 解析结果：接口 code、纯音乐标志与行列表。
      */
     public static final class LyricData {
+        @NonNull
+        public final ResultType type;
         public final int code;
         public final boolean pureMusic;
         @Nullable
         public final List<LyricLineData> lines;
 
-        public LyricData(int code, boolean pureMusic, @Nullable List<LyricLineData> lines) {
+        public LyricData(@NonNull ResultType type, int code, boolean pureMusic,
+                         @Nullable List<LyricLineData> lines) {
+            this.type = type;
             this.code = code;
             this.pureMusic = pureMusic;
             this.lines = lines;
         }
 
         public boolean hasLyrics() {
-            return lines != null && !lines.isEmpty();
+            return type == ResultType.READY && lines != null && !lines.isEmpty();
         }
     }
 

--- a/app/src/main/java/com/hchen/superlyric/hook/music/online/netease/NeteasePublisher.java
+++ b/app/src/main/java/com/hchen/superlyric/hook/music/online/netease/NeteasePublisher.java
@@ -50,9 +50,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -103,9 +105,12 @@ public abstract class NeteasePublisher extends AbsPublisher {
     // song + lyric + lastShownIndex 原子可见；歌词写入 / 清空 / 行推进均以
     // compareAndSet 原子替换，避免「读-改-写」覆盖并发更新的新快照
     private final AtomicReference<TrackSnapshot> mTrackRef = new AtomicReference<>();
+    private final AtomicLong mTrackGeneration = new AtomicLong();
 
     // 42ms 行推进：mIsRunning 防重入；mLoopToken 使 stopLoop → startLoop 时序下旧轮询链立即失效
+    private HandlerThread mLyricThread;
     private Handler mLyricHandler;
+    private boolean mHooksInitialized;
     private volatile boolean mIsRunning = false;
     private volatile long mLoopToken = 0L;
 
@@ -130,8 +135,12 @@ public abstract class NeteasePublisher extends AbsPublisher {
     private final AtomicLong mRetryToken = new AtomicLong();
 
     // 异步拉取（缓存线程池：快速切歌时新请求不被慢的旧请求阻塞）
-    private final ExecutorService mDownloadExecutor = Executors.newCachedThreadPool();
-    private final Set<Long> mDownloadingIds = ConcurrentHashMap.newKeySet();
+    private final ThreadPoolExecutor mDownloadExecutor = new ThreadPoolExecutor(
+        2, 2, 0L, TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<>(4),
+        new ThreadPoolExecutor.AbortPolicy()
+    );
+    private final Set<String> mDownloadingIds = ConcurrentHashMap.newKeySet();
 
     /**
      * 歌曲上下文快照：数字音轨标识 + 标题/歌手/专辑/时长。
@@ -179,13 +188,16 @@ public abstract class NeteasePublisher extends AbsPublisher {
      * 歌曲上下文快照：当前歌曲 + 歌词（可为空）+ 已展示行索引，整体原子替换。
      */
     private static final class TrackSnapshot {
+        final long generation;
         @NonNull
         final SongInfo song;
         @Nullable
         final LyricSnapshot lyric;
         final int lastShownIndex;
 
-        TrackSnapshot(@NonNull SongInfo song, @Nullable LyricSnapshot lyric, int lastShownIndex) {
+        TrackSnapshot(long generation, @NonNull SongInfo song, @Nullable LyricSnapshot lyric,
+                      int lastShownIndex) {
+            this.generation = generation;
             this.song = song;
             this.lyric = lyric;
             this.lastShownIndex = lastShownIndex;
@@ -193,17 +205,17 @@ public abstract class NeteasePublisher extends AbsPublisher {
 
         @NonNull
         TrackSnapshot withLyric(@NonNull LyricSnapshot newLyric) {
-            return new TrackSnapshot(song, newLyric, -1);
+            return new TrackSnapshot(generation, song, newLyric, -1);
         }
 
         @NonNull
         TrackSnapshot clearLyric() {
-            return new TrackSnapshot(song, null, -1);
+            return new TrackSnapshot(generation, song, null, -1);
         }
 
         @NonNull
         TrackSnapshot withShownIndex(int index) {
-            return new TrackSnapshot(song, lyric, index);
+            return new TrackSnapshot(generation, song, lyric, index);
         }
     }
 
@@ -222,15 +234,20 @@ public abstract class NeteasePublisher extends AbsPublisher {
     }
 
     @Override
-    protected void onPackageReady(@NonNull XposedModuleInterface.PackageReadyParam param) {
+    protected synchronized void onPackageReady(@NonNull XposedModuleInterface.PackageReadyParam param) {
         super.onPackageReady(param);
-        HandlerThread lyricThread = new HandlerThread("NeteasePublisherThread");
-        lyricThread.start();
-        mLyricHandler = new Handler(lyricThread.getLooper());
+        if (mHooksInitialized) {
+            logD(TAG, "Netease network hooks already initialized for " + param.getPackageName());
+            return;
+        }
+        mLyricThread = new HandlerThread("NeteasePublisherThread");
+        mLyricThread.start();
+        mLyricHandler = new Handler(mLyricThread.getLooper());
 
         NeteaseLogicHijacking.bypassPackProtection();
         hookMediaSession();
         hookPlaybackState();
+        mHooksInitialized = true;
         logI(TAG, "Netease network path hooks loaded (package: " + param.getPackageName() + ")");
     }
 
@@ -373,6 +390,12 @@ public abstract class NeteasePublisher extends AbsPublisher {
         switch (mPlayback.state) {
             case PlaybackState.STATE_PLAYING:
                 dispatchSourceEvent(LyricSourceMachine.Event.playing());
+                TrackSnapshot current = mTrackRef.get();
+                long currentId = current == null ? -1L : current.song.id;
+                if (current != null && LyricSourceMachine.shouldRetry(mSourceState)
+                    && !mDownloadingIds.contains(taskKey(currentId, current.generation))) {
+                    scheduleLyricRetry(currentId, current.generation);
+                }
                 startLoop();
                 break;
             case PlaybackState.STATE_STOPPED:
@@ -395,6 +418,7 @@ public abstract class NeteasePublisher extends AbsPublisher {
     private void onMetadataChanged(@NonNull MediaMetadata metadata) {
         long id = extractSongId(metadata);
         if (id <= 0L) {
+            NeteaseLyricAnalysis.cancelExcept(-1L);
             logD(TAG, "setMetadata: no valid numeric id, treat as ad/unknown, sendStop");
             // 广告 / 非歌曲：清空上下文与歌词快照，防止旧歌曲晚到响应或残留行误发
             cancelLyricRetry(currentSongId());
@@ -411,6 +435,7 @@ public abstract class NeteasePublisher extends AbsPublisher {
             return;
         }
 
+        NeteaseLyricAnalysis.cancelExcept(id);
         // 切歌：立即清空旧歌词与显示；下次切歌重新尝试网络路径
         cancelLyricRetry(currentSongId());
         sendStop();
@@ -420,25 +445,27 @@ public abstract class NeteasePublisher extends AbsPublisher {
         String artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST);
         String album = metadata.getString(MediaMetadata.METADATA_KEY_ALBUM);
         long duration = metadata.getLong(MediaMetadata.METADATA_KEY_DURATION);
-        mTrackRef.set(new TrackSnapshot(
-            new SongInfo(
-                id,
-                title != null ? title : "",
-                artist != null ? artist : "",
-                album != null ? album : "",
-                duration
-            ),
-            null,
-            -1
-        ));
-        logD(TAG, "Track changed: id=" + id + ", title=" + title + ", artist=" + artist
-            + ", album=" + album + ", retry network path");
-
-        dispatchSourceEvent(LyricSourceMachine.Event.trackChanged(id));
+        long generation = mTrackGeneration.incrementAndGet();
+        synchronized (mSourceStateLock) {
+            mTrackRef.set(new TrackSnapshot(
+                generation,
+                new SongInfo(
+                    id,
+                    title != null ? title : "",
+                    artist != null ? artist : "",
+                    album != null ? album : "",
+                    duration
+                ),
+                null,
+                -1
+            ));
+            dispatchSourceEvent(LyricSourceMachine.Event.trackChanged(id));
+        }
+        logD(TAG, "Track changed: id=" + id + ", retry network path");
 
         // 首次切歌惰性重试：即便定时重试全部失败，第一首歌前仍有机会完成设置联动
         linkLyricSetting();
-        fetchLyricsForTrack(id);
+        fetchLyricsForTrack(id, generation);
     }
 
     /**
@@ -511,19 +538,32 @@ public abstract class NeteasePublisher extends AbsPublisher {
      * 位置插值：上次采样位置 + 速度 × 流逝时间（灭屏不停表）。
      */
     private static long estimatePosition(@NonNull PlaybackSnapshot playback, long now) {
+        long base = Math.max(0L, playback.position);
+        if (!Float.isFinite(playback.speed) || playback.speed < 0f || now <= playback.anchorTime) return base;
         long elapsed = now - playback.anchorTime;
-        return playback.position + (long) (elapsed * playback.speed);
+        double delta = elapsed * (double) playback.speed;
+        if (!Double.isFinite(delta) || delta >= Long.MAX_VALUE) return Long.MAX_VALUE;
+        try {
+            return Math.max(0L, Math.addExact(base, (long) delta));
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
     }
 
     /**
      * 顺序查找 start ≤ 位置 < end 的行。
      */
     private static int findLineIndex(@NonNull List<NeteaseLyricAnalysis.LyricLineData> lines, long position) {
-        for (int i = 0; i < lines.size(); i++) {
+        int low = 0;
+        int high = lines.size();
+        while (low < high) {
+            int mid = (low + high) >>> 1;
+            if (lines.get(mid).start <= position) low = mid + 1;
+            else high = mid;
+        }
+        for (int i = low - 1; i >= 0; i--) {
             NeteaseLyricAnalysis.LyricLineData line = lines.get(i);
-            if (position >= line.start && position < line.end) {
-                return i;
-            }
+            if (position >= line.start && position < line.end) return i;
         }
         return -1;
     }
@@ -544,8 +584,7 @@ public abstract class NeteasePublisher extends AbsPublisher {
         }
 
         sendLyric(data);
-        logD(TAG, "sendLyric: [" + song.title + " - " + song.artist + " - " + song.album + "] "
-            + line.text + (TextUtils.isEmpty(translationSlot) ? "" : " / " + translationSlot));
+        logD(TAG, "sendLyric: track=" + song.id + ", start=" + line.start);
     }
 
     /**
@@ -561,48 +600,98 @@ public abstract class NeteasePublisher extends AbsPublisher {
 
     // ------------------------------ 拉取与缓存 ------------------------------
 
-    private void fetchLyricsForTrack(long id) {
-        // 独立命名空间（宿主私有缓存，与 LyricProvider 同方案）：
-        // cacheDir/SuperLyric/lyric/{provider}/{id}.json
+    private static String taskKey(long id, long generation) {
+        return id + "#" + generation;
+    }
+
+    private boolean isCurrentTrack(long id, long generation) {
+        TrackSnapshot current = mTrackRef.get();
+        return current != null && current.generation == generation && current.song.id == id;
+    }
+
+    private void fetchLyricsForTrack(long id, long generation) {
+        String taskKey = taskKey(id, generation);
+        if (!mDownloadingIds.add(taskKey)) {
+            logD(TAG, "Lyric already loading for " + id);
+            return;
+        }
+        try {
+            mDownloadExecutor.execute(() -> loadLyricsForTrack(id, generation, taskKey));
+        } catch (RejectedExecutionException e) {
+            mDownloadingIds.remove(taskKey);
+            handleRetryableFailure(id, generation, "Lyric worker queue full", e);
+        }
+    }
+
+    private void loadLyricsForTrack(long id, long generation, @NonNull String taskKey) {
         String cacheProvider = lyricCacheProvider();
         String cacheKey = String.valueOf(id);
+        try {
+            if (!isCurrentTrack(id, generation)) return;
 
-        String cached = LyricCacheStore.get(mAppContext, cacheProvider, cacheKey);
-        if (cached != null) {
-            logD(TAG, "Lyric cache hit for " + id + ", no network request");
-            applyLyrics(id, cached);
-            return;
-        }
-
-        if (!mDownloadingIds.add(id)) {
-            logD(TAG, "Lyric already downloading for " + id);
-            return;
-        }
-
-        mDownloadExecutor.execute(() -> {
-            try {
-                String json = NeteaseLyricAnalysis.fetchLyricJson(id);
-                logD(TAG, "Lyric fetched for " + id + ", json length=" + json.length());
-                // 仅歌词就绪（含翻译/音译）才写缓存；无歌词 / 纯音乐 / 解析失败不缓存，
-                // 避免"无歌词"响应被永久缓存，导致版权方补词后仍显示空白
-                if (applyLyrics(id, json)) {
-                    LyricCacheStore.put(mAppContext, cacheProvider, cacheKey, json);
-                    logD(TAG, "Lyric cache written: " + cacheProvider + "/" + cacheKey + ".json");
-                }
-            } catch (Exception e) {
-                logE(TAG, "Failed to fetch lyric for " + id, e);
-                // 过期音轨（切歌 / 广告）：状态机按 trackId 校验会忽略，无需再走失败 / 重试
-                SongInfo song = currentSong();
-                if (song == null || song.id != id) {
-                    logD(TAG, "Ignore retry for stale track " + id);
+            String cached = LyricCacheStore.get(mAppContext, cacheProvider, cacheKey);
+            if (cached != null) {
+                NeteaseLyricAnalysis.LyricData cachedData = NeteaseLyricAnalysis.parseLyrics(cached);
+                if (cachedData.hasLyrics()) {
+                    logD(TAG, "Lyric cache hit for " + id + ", no network request");
+                    applyLyrics(id, generation, cachedData);
                     return;
                 }
-                dispatchSourceEvent(LyricSourceMachine.Event.fetchFailed(id));
-                scheduleLyricRetry(id);
-            } finally {
-                mDownloadingIds.remove(id);
+                LyricCacheStore.delete(mAppContext, cacheProvider, cacheKey);
             }
-        });
+
+            String json = NeteaseLyricAnalysis.fetchLyricJson(id);
+            if (!isCurrentTrack(id, generation)) return;
+            NeteaseLyricAnalysis.LyricData data = NeteaseLyricAnalysis.parseLyrics(json);
+            switch (data.type) {
+                case READY:
+                    if (applyLyrics(id, generation, data)) {
+                        LyricCacheStore.put(mAppContext, cacheProvider, cacheKey, json);
+                    }
+                    break;
+                case EMPTY:
+                case PURE_MUSIC:
+                    applyLyrics(id, generation, data);
+                    break;
+                case MALFORMED:
+                    handleRetryableFailure(id, generation, "Malformed lyric response", null);
+                    break;
+                case API_ERROR:
+                    handleRetryableFailure(id, generation, "Lyric API error code=" + data.code, null);
+                    break;
+            }
+        } catch (NeteaseLyricAnalysis.OversizeException e) {
+            finishEmpty(id, generation, "Lyric response exceeds budget for " + id);
+        } catch (NeteaseLyricAnalysis.HttpStatusException e) {
+            if (e.retryable) handleRetryableFailure(id, generation, "Retryable HTTP " + e.code, e);
+            else finishEmpty(id, generation, "Non-retryable HTTP " + e.code + " for " + id);
+        } catch (Exception e) {
+            handleRetryableFailure(id, generation, "Failed to fetch lyric", e);
+        } finally {
+            mDownloadingIds.remove(taskKey);
+        }
+    }
+
+    private void handleRetryableFailure(long id, long generation, @NonNull String message,
+                                        @Nullable Throwable error) {
+        synchronized (mSourceStateLock) {
+            if (!isCurrentTrack(id, generation)) return;
+            if (error == null) logW(TAG, message + " for " + id);
+            else logE(TAG, message + " for " + id, error);
+            dispatchSourceEvent(LyricSourceMachine.Event.fetchFailed(id));
+        }
+        scheduleLyricRetry(id, generation);
+    }
+
+    private void finishEmpty(long id, long generation, @NonNull String message) {
+        synchronized (mSourceStateLock) {
+            TrackSnapshot current = mTrackRef.get();
+            if (current == null || current.generation != generation || current.song.id != id) return;
+            if (!mTrackRef.compareAndSet(current, current.clearLyric())) return;
+            clearRetryFor(id);
+            dispatchSourceEvent(LyricSourceMachine.Event.fetchEmpty(id));
+        }
+        logD(TAG, message);
     }
 
     /**
@@ -610,7 +699,8 @@ public abstract class NeteasePublisher extends AbsPublisher {
      * 所有调度经 {@code mLyricHandler}，{@code mRetryToken} 使切歌 / 停止 / 暂停后的
      * 旧任务立即失效，不残留。
      */
-    private void scheduleLyricRetry(long id) {
+    private void scheduleLyricRetry(long id, long generation) {
+        if (!isCurrentTrack(id, generation)) return;
         LyricSourceMachine.State state = mSourceState;
         if (state.trackId != id) return;
         // 暂停 / 停止等非播放状态下不安排新重试（与取消语义一致，不残留任务）
@@ -633,7 +723,7 @@ public abstract class NeteasePublisher extends AbsPublisher {
         logI(TAG, "Lyric retry scheduled for " + id + " retry#" + state.failedAttempts
             + ", delay=" + delay + "ms");
         mLyricHandler.postDelayed(() -> {
-            if (token != mRetryToken.get()) return;
+            if (token != mRetryToken.get() || !isCurrentTrack(id, generation)) return;
             if (mSourceState.trackId != id) {
                 clearRetryFor(id);
                 return;
@@ -643,7 +733,7 @@ public abstract class NeteasePublisher extends AbsPublisher {
                 return;
             }
             logD(TAG, "Lyric retry executing for " + id + " retry#" + mSourceState.failedAttempts);
-            fetchLyricsForTrack(id);
+            fetchLyricsForTrack(id, generation);
         }, delay);
     }
 
@@ -730,53 +820,48 @@ public abstract class NeteasePublisher extends AbsPublisher {
      * 应用歌词：解析并原子写入快照、走状态机事件；返回歌词是否已就绪并可用
      * （纯音乐 / 无歌词 / 过期响应返回 {@code false}，调用方据此决定是否写缓存）。
      */
-    private boolean applyLyrics(long id, @NonNull String json) {
-        // 竞态防护：异步拉取完成时校验当前音轨（与当前歌曲快照比对）
+    private boolean applyLyrics(long id, long generation,
+                                @NonNull NeteaseLyricAnalysis.LyricData data) {
+        synchronized (mSourceStateLock) {
+            return applyLyricsLocked(id, generation, data);
+        }
+    }
+
+    private boolean applyLyricsLocked(long id, long generation,
+                                      @NonNull NeteaseLyricAnalysis.LyricData data) {
         TrackSnapshot current = mTrackRef.get();
-        if (current == null || current.song.id != id) {
-            logD(TAG, "Stale lyric response for " + id
-                + ", current=" + (current == null ? -1 : current.song.id) + ", discard");
+        if (current == null || current.generation != generation || current.song.id != id) {
+            logD(TAG, "Stale lyric response for " + id + ", discard");
             return false;
         }
 
-        NeteaseLyricAnalysis.LyricData data = NeteaseLyricAnalysis.parseLyrics(json);
-        if (data.pureMusic) {
+        if (data.type == NeteaseLyricAnalysis.ResultType.PURE_MUSIC || !data.hasLyrics()) {
+            if (!mTrackRef.compareAndSet(current, current.clearLyric())) return false;
             clearRetryFor(id);
             dispatchSourceEvent(LyricSourceMachine.Event.fetchEmpty(id));
-            mTrackRef.compareAndSet(current, current.clearLyric());
-            logD(TAG, "Pure music flag for " + id + ", keep blank");
-            return false;
-        }
-        if (!data.hasLyrics()) {
-            clearRetryFor(id);
-            dispatchSourceEvent(LyricSourceMachine.Event.fetchEmpty(id));
-            mTrackRef.compareAndSet(current, current.clearLyric());
-            logD(TAG, "No lyric lines for " + id + " (code=" + data.code + "), keep blank");
+            logD(TAG, data.type == NeteaseLyricAnalysis.ResultType.PURE_MUSIC
+                ? "Pure music flag for " + id + ", keep blank"
+                : "No lyric lines for " + id + " (code=" + data.code + "), keep blank");
             return false;
         }
 
-        // 曲内重试成功：清除待执行重试并走 RETRY_SUCCEEDED 接管（重试期间的唯一接管通道）
         boolean retrySuccess = mRetryTrackId == id;
         int failedBefore = mSourceState.failedAttempts;
-        if (retrySuccess) {
-            clearRetryFor(id);
-        }
-        // 状态机：网络歌词就绪 → 固化网络契约（迟到的旧请求已由顶部 trackId 校验拦截）
-        dispatchSourceEvent(retrySuccess
-            ? LyricSourceMachine.Event.retrySucceeded(id)
-            : LyricSourceMachine.Event.fetchSucceeded(id));
-        // CAS 写入：快照已换代（切歌 / 重新拉取）时不覆盖，由新状态机事件负责后续
         if (!mTrackRef.compareAndSet(current, current.withLyric(new LyricSnapshot(id, data)))) {
             logD(TAG, "Track changed while applying lyric for " + id + ", discard");
             return false;
         }
+        if (retrySuccess) clearRetryFor(id);
+        dispatchSourceEvent(retrySuccess
+            ? LyricSourceMachine.Event.retrySucceeded(id)
+            : LyricSourceMachine.Event.fetchSucceeded(id));
 
         long wordLines = data.lines.stream().filter(line -> line.words != null).count();
         long translateLines = data.lines.stream().filter(line -> line.translation != null).count();
         long romaLines = data.lines.stream().filter(line -> line.roma != null).count();
         logD(TAG, "Lyrics ready for " + id + ", lines=" + data.lines.size()
             + ", wordLines=" + wordLines + ", translateLines=" + translateLines
-            + ", romaLines=" + romaLines + ", first=" + data.lines.get(0).text);
+            + ", romaLines=" + romaLines);
 
         if (retrySuccess) {
             logI(TAG, "Lyric retry succeeded for " + id + " after " + failedBefore

--- a/app/src/main/java/com/hchen/superlyric/hook/music/online/spotify/SpotifyLyricAnalysis.java
+++ b/app/src/main/java/com/hchen/superlyric/hook/music/online/spotify/SpotifyLyricAnalysis.java
@@ -25,17 +25,24 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.hchen.hooktool.log.XposedLog;
 import com.hchen.superlyricapi.SuperLyricWord;
+import com.hchen.superlyric.utils.LyricCacheStore;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -62,18 +69,32 @@ public final class SpotifyLyricAnalysis {
         "x-client-id"
     );
 
-    /**
-     * 会话头存储：key 统一小写，由 hook 填充，全局复用。
-     */
-    private static final Map<String, String> mHeaders = new ConcurrentHashMap<>();
+    public static final class HeaderSnapshot {
+        @NonNull
+        final Map<String, String> headers;
+        public final long generation;
+        public final boolean valid;
+
+        private HeaderSnapshot(@NonNull Map<String, String> headers, long generation, boolean valid) {
+            this.headers = headers;
+            this.generation = generation;
+            this.valid = valid;
+        }
+    }
+
+    private static final AtomicReference<HeaderSnapshot> mHeaders =
+        new AtomicReference<>(new HeaderSnapshot(Collections.emptyMap(), 0L, false));
 
     private static volatile boolean mHeaderCompleteLogged = false;
 
     private static final Gson gson = new Gson();
 
+    private static final Map<String, Call> activeCalls = new ConcurrentHashMap<>();
+
     private static final OkHttpClient client = new OkHttpClient.Builder()
         .connectTimeout(15, TimeUnit.SECONDS)
         .readTimeout(15, TimeUnit.SECONDS)
+        .callTimeout(30, TimeUnit.SECONDS)
         .build();
 
     private SpotifyLyricAnalysis() {
@@ -89,28 +110,47 @@ public final class SpotifyLyricAnalysis {
     }
 
     /**
-     * 保存捕获到的会话头（key 已小写）。
+     * 从同一次 okhttp Headers 构造参数发布完整会话头快照。
+     *
+     * @param namesAndValues okhttp 名称和值交替排列的数组
+     * @return 本次数据是否包含全部关键头
      */
-    public static void setHeader(@NonNull String keyLowercase, @NonNull String value) {
-        mHeaders.put(keyLowercase, value);
-        XposedLog.logD(TAG, "Captured session header: " + keyLowercase + "=" + mask(value));
-        if (!mHeaderCompleteLogged && hasAllRequiredHeaders()) {
-            mHeaderCompleteLogged = true;
-            XposedLog.logI(TAG, "All 4 required session headers captured: " + KEYS_REQUIRED);
+    @Nullable
+    public static HeaderSnapshot updateHeaders(@NonNull String[] namesAndValues) {
+        Map<String, String> captured = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < namesAndValues.length; i += 2) {
+            String name = namesAndValues[i];
+            String value = namesAndValues[i + 1];
+            if (name == null || value == null) continue;
+            String lower = name.toLowerCase(Locale.ENGLISH);
+            if (isKeyRequired(lower)) captured.put(lower, value);
+        }
+        if (!captured.keySet().containsAll(KEYS_REQUIRED)) return null;
+
+        Map<String, String> immutable = Collections.unmodifiableMap(captured);
+        while (true) {
+            HeaderSnapshot current = mHeaders.get();
+            if (current.valid && current.headers.equals(immutable)) return current;
+            HeaderSnapshot next = new HeaderSnapshot(immutable, current.generation + 1L, true);
+            if (mHeaders.compareAndSet(current, next)) {
+                if (!mHeaderCompleteLogged) {
+                    mHeaderCompleteLogged = true;
+                    XposedLog.logI(TAG, "All required session headers captured");
+                }
+                return next;
+            }
         }
     }
 
-    /**
-     * 会话头是否已齐全（4 个关键头全部捕获）。
-     */
-    public static boolean hasAllRequiredHeaders() {
-        return mHeaders.keySet().containsAll(KEYS_REQUIRED);
+    @Nullable
+    public static HeaderSnapshot currentHeaders() {
+        HeaderSnapshot snapshot = mHeaders.get();
+        return snapshot.valid ? snapshot : null;
     }
 
-    private static String mask(@NonNull String value) {
-        int len = value.length();
-        if (len <= 8) return "****";
-        return value.substring(0, 4) + "****" + value.substring(len - 4);
+    public static void invalidate(@NonNull HeaderSnapshot requestSnapshot) {
+        mHeaders.compareAndSet(requestSnapshot,
+            new HeaderSnapshot(Collections.emptyMap(), requestSnapshot.generation, false));
     }
 
     // ------------------------------ 网络拉取 ------------------------------
@@ -124,7 +164,7 @@ public final class SpotifyLyricAnalysis {
      * @throws IOException           网络错误 / 非成功状态码
      */
     @NonNull
-    public static byte[] fetchLyric(@NonNull String id) throws IOException {
+    public static byte[] fetchLyric(@NonNull String id, @NonNull HeaderSnapshot headers) throws IOException {
         String url = BASE_URL + id
             + "?vocalRemoval=true&clientLanguage=" + Locale.getDefault().toLanguageTag()
             + "&preview=false";
@@ -137,20 +177,77 @@ public final class SpotifyLyricAnalysis {
             .addHeader("accept", "application/protobuf")
             .addHeader("content-type", "application/protobuf")
             .addHeader("app-platform", "Android");
-        mHeaders.forEach(builder::addHeader);
+        headers.headers.forEach(builder::addHeader);
 
         Request request = builder.build();
-        try (Response response = client.newCall(request).execute()) {
+        Call call = client.newCall(request);
+        Call previous = activeCalls.put(id, call);
+        if (previous != null) previous.cancel();
+        try (Response response = call.execute()) {
             int code = response.code();
+            if (code == 401 || code == 403) {
+                invalidate(headers);
+                throw new AuthenticationException(code, headers.generation);
+            }
             if (code == 404) {
                 throw new NoFoundLyricException(id, "No lyric found for " + id);
             }
             if (!response.isSuccessful()) {
-                throw new IOException("HTTP error code: " + code + ", msg: " + response.message());
+                throw new HttpStatusException(code, code == 429 || code >= 500);
             }
 
-            return response.body().bytes();
+            if (response.body() == null) {
+                throw new IOException("Empty lyric response for " + id);
+            }
+            long contentLength = response.body().contentLength();
+            if (contentLength > LyricCacheStore.MAX_PAYLOAD_BYTES) {
+                throw new OversizeException(LyricCacheStore.MAX_PAYLOAD_BYTES);
+            }
+            return readLimited(response.body().byteStream(), LyricCacheStore.MAX_PAYLOAD_BYTES);
+        } finally {
+            activeCalls.remove(id, call);
         }
+    }
+
+    public static void cancelExcept(@Nullable String currentId) {
+        activeCalls.forEach((id, call) -> {
+            if (currentId == null || !currentId.equals(id)) call.cancel();
+        });
+    }
+
+    @NonNull
+    private static byte[] readLimited(@NonNull InputStream input, int maxBytes) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream(Math.min(maxBytes, 8192));
+        byte[] buffer = new byte[8192];
+        int total = 0;
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            if (read > maxBytes - total) throw new OversizeException(maxBytes);
+            output.write(buffer, 0, read);
+            total += read;
+        }
+        return output.toByteArray();
+    }
+
+    public enum ParseType { READY, EMPTY, MALFORMED }
+
+    public static final class ParseResult {
+        @NonNull
+        public final ParseType type;
+        @Nullable
+        public final List<SpotifyLine> lines;
+
+        private ParseResult(@NonNull ParseType type, @Nullable List<SpotifyLine> lines) {
+            this.type = type;
+            this.lines = lines;
+        }
+    }
+
+    @NonNull
+    public static ParseResult parseResult(@NonNull byte[] data) {
+        List<SpotifyLine> lines = parseLyrics(data);
+        if (lines == null) return new ParseResult(ParseType.MALFORMED, null);
+        return new ParseResult(lines.isEmpty() ? ParseType.EMPTY : ParseType.READY, lines);
     }
 
     // ------------------------------ 解析与规整 ------------------------------
@@ -173,7 +270,7 @@ public final class SpotifyLyricAnalysis {
                 return null;
             }
             return normalizeLines(mapJsonLines(response.lyrics.lines));
-        } catch (JsonSyntaxException e) {
+        } catch (JsonSyntaxException | IndexOutOfBoundsException | IllegalArgumentException e) {
             XposedLog.logE(TAG, "Failed to parse lyric json", e);
             return null;
         }
@@ -184,8 +281,15 @@ public final class SpotifyLyricAnalysis {
      */
     @Nullable
     public static List<SpotifyLine> parseLyrics(@NonNull byte[] data) {
-        if (data.length > 0 && data[0] == '{') {
-            return parseLyrics(new String(data, StandardCharsets.UTF_8));
+        int offset = data.length >= 3 && data[0] == (byte) 0xEF
+            && data[1] == (byte) 0xBB && data[2] == (byte) 0xBF ? 3 : 0;
+        int first = offset;
+        while (first < data.length && (data[first] == ' ' || data[first] == '\t'
+            || data[first] == '\r' || data[first] == '\n')) {
+            first++;
+        }
+        if (first < data.length && data[first] == '{') {
+            return parseLyrics(new String(data, offset, data.length - offset, StandardCharsets.UTF_8));
         }
         return parseProtobufLyrics(data);
     }
@@ -230,6 +334,24 @@ public final class SpotifyLyricAnalysis {
 
     // ------------------------------ protobuf 解析（手写 wire format） ------------------------------
 
+    private static final int MAX_PROTO_LINES = 10000;
+    private static final int MAX_PROTO_SYLLABLES_PER_LINE = 10000;
+    private static final int MAX_PROTO_STRING_BYTES = 64 * 1024;
+    private static final int MAX_PROTO_TAGS = 200000;
+
+    private static final class ParseBudget {
+        int tags = MAX_PROTO_TAGS;
+        int lines = MAX_PROTO_LINES;
+
+        void consumeTag() throws IOException {
+            if (--tags < 0) throw new IOException("Protobuf tag budget exceeded");
+        }
+
+        void consumeLine() throws IOException {
+            if (--lines < 0) throw new IOException("Protobuf line budget exceeded");
+        }
+    }
+
     /**
      * 解析 color-lyrics 接口的 protobuf 响应（schema 由 Surge 抓包逆向）：
      * <pre>
@@ -247,7 +369,7 @@ public final class SpotifyLyricAnalysis {
     @Nullable
     private static List<SpotifyLine> parseProtobufLyrics(@NonNull byte[] data) {
         try {
-            ProtoReader reader = new ProtoReader(data);
+            ProtoReader reader = new ProtoReader(data, new ParseBudget());
             LyricsData lyrics = null;
             while (reader.hasMore()) {
                 int tag = reader.readTag();
@@ -261,8 +383,8 @@ public final class SpotifyLyricAnalysis {
                 }
             }
             return lyrics == null ? null : normalizeLines(lyrics.lines);
-        } catch (Throwable t) {
-            XposedLog.logE(TAG, "Failed to parse lyric protobuf", t);
+        } catch (IOException | RuntimeException e) {
+            XposedLog.logE(TAG, "Failed to parse lyric protobuf", e);
             return null;
         }
     }
@@ -275,12 +397,15 @@ public final class SpotifyLyricAnalysis {
             int field = tag >>> 3;
             int wireType = tag & 7;
             if (field == 2 && wireType == 2) {
+                reader.budget.consumeLine();
                 int lineEnd = reader.ensureEnd(reader.readLength());
+                if (lineEnd > end) throw new IOException("Line exceeds parent message");
                 lines.add(parseLyricLine(reader, lineEnd));
             } else {
                 reader.skipField(wireType);
             }
         }
+        if (reader.pos != end) throw new IOException("Lyrics message boundary mismatch");
         return new LyricsData(lines);
     }
 
@@ -301,10 +426,15 @@ public final class SpotifyLyricAnalysis {
             } else if (wireType == 2) {
                 int len = reader.readLength();
                 int fieldEnd = reader.ensureEnd(len);
+                if (fieldEnd > end) throw new IOException("Field exceeds parent message");
                 if (field == 2) {
+                    if (len > MAX_PROTO_STRING_BYTES) throw new IOException("Lyric string too large");
                     words = new String(reader.readBytes(len), StandardCharsets.UTF_8);
                 } else if (field == 3) {
                     if (syllables == null) syllables = new ArrayList<>();
+                    if (syllables.size() >= MAX_PROTO_SYLLABLES_PER_LINE) {
+                        throw new IOException("Syllable budget exceeded");
+                    }
                     Syllable syllable = parseSyllable(reader, fieldEnd);
                     syllables.add(syllable);
                 } else {
@@ -314,7 +444,7 @@ public final class SpotifyLyricAnalysis {
                 reader.skipField(wireType);
             }
         }
-        // schema 中行级 end_time_ms 不存在（缺省为 0），由规整阶段按下一行兜底
+        if (reader.pos != end) throw new IOException("Line message boundary mismatch");
         return new LyricLine(startTimeMs, words, 0L, null, syllables);
     }
 
@@ -332,6 +462,7 @@ public final class SpotifyLyricAnalysis {
                 if (field == 1) {
                     startTimeMs = value;
                 } else if (field == 2) {
+                    if (value > Integer.MAX_VALUE) throw new IOException("Invalid syllable count");
                     count = (int) value;
                 } else if (field == 3) {
                     endTimeMs = value;
@@ -340,6 +471,7 @@ public final class SpotifyLyricAnalysis {
                 reader.skipField(wireType);
             }
         }
+        if (reader.pos != end) throw new IOException("Syllable message boundary mismatch");
         return new Syllable(startTimeMs, count, endTimeMs);
     }
 
@@ -349,10 +481,12 @@ public final class SpotifyLyricAnalysis {
      */
     private static final class ProtoReader {
         private final byte[] data;
+        private final ParseBudget budget;
         private int pos;
 
-        ProtoReader(@NonNull byte[] data) {
+        ProtoReader(@NonNull byte[] data, @NonNull ParseBudget budget) {
             this.data = data;
+            this.budget = budget;
         }
 
         boolean hasMore() {
@@ -373,6 +507,7 @@ public final class SpotifyLyricAnalysis {
         }
 
         int readTag() throws IOException {
+            budget.consumeTag();
             long tag = readVarint();
             if (tag <= 0 || tag > 0xFFFFFFFFL) throw new IOException("Invalid tag: " + tag);
             return (int) tag;
@@ -385,9 +520,8 @@ public final class SpotifyLyricAnalysis {
         }
 
         int ensureEnd(int length) throws IOException {
-            int end = pos + length;
-            if (length < 0 || end > data.length) throw new IOException("Truncated field");
-            return end;
+            if (length < 0 || length > data.length - pos) throw new IOException("Truncated field");
+            return pos + length;
         }
 
         @NonNull
@@ -425,19 +559,30 @@ public final class SpotifyLyricAnalysis {
 
     @NonNull
     private static List<SpotifyLine> normalizeLines(@NonNull List<LyricLine> lines) {
-        List<SpotifyLine> result = new ArrayList<>(lines.size());
-        for (int i = 0; i < lines.size(); i++) {
-            LyricLine line = lines.get(i);
-            if (line == null || line.words == null || line.words.trim().isEmpty()) {
-                continue;
+        List<LyricLine> validLines = new ArrayList<>(lines.size());
+        for (LyricLine line : lines) {
+            if (line != null && line.startTimeMs >= 0L
+                && line.words != null && !line.words.trim().isEmpty()) {
+                validLines.add(line);
             }
+        }
+        validLines.sort((left, right) -> Long.compare(left.startTimeMs, right.startTimeMs));
+
+        List<SpotifyLine> result = new ArrayList<>(validLines.size());
+        for (int i = 0; i < validLines.size(); i++) {
+            LyricLine line = validLines.get(i);
+            long endTimeMs = effectiveEndTime(validLines, i, line);
+            if (i + 1 < validLines.size()) {
+                endTimeMs = Math.min(endTimeMs, validLines.get(i + 1).startTimeMs);
+            }
+            if (endTimeMs <= line.startTimeMs) continue;
 
             result.add(new SpotifyLine(
                 line.words,
                 line.startTimeMs,
-                effectiveEndTime(lines, i, line),
+                endTimeMs,
                 line.transliteratedWords,
-                toSuperLyricWords(line.words, line.syllables)
+                toSuperLyricWords(line.words, line.syllables, line.startTimeMs, endTimeMs)
             ));
         }
         return result;
@@ -448,11 +593,13 @@ public final class SpotifyLyricAnalysis {
      * 最后一行兜底 {@code +5000ms}。
      */
     private static long effectiveEndTime(@NonNull List<LyricLine> lines, int index, @NonNull LyricLine line) {
-        if (line.endTimeMs != 0L) return line.endTimeMs;
-        if (index + 1 < lines.size() && lines.get(index + 1) != null) {
+        if (line.endTimeMs > line.startTimeMs) return line.endTimeMs;
+        if (index + 1 < lines.size()) {
             return lines.get(index + 1).startTimeMs;
         }
-        return line.startTimeMs + 5000L;
+        return line.startTimeMs <= Long.MAX_VALUE - 5000L
+            ? line.startTimeMs + 5000L
+            : Long.MAX_VALUE;
     }
 
     /**
@@ -460,23 +607,32 @@ public final class SpotifyLyricAnalysis {
      * 计数与文本长度不匹配时放弃逐字（返回 null，退回纯行级）。
      */
     @Nullable
-    private static SuperLyricWord[] toSuperLyricWords(@NonNull String text, @Nullable List<Syllable> syllables) {
+    private static SuperLyricWord[] toSuperLyricWords(@NonNull String text, @Nullable List<Syllable> syllables,
+                                                       long lineStart, long lineEnd) {
         if (syllables == null || syllables.isEmpty()) return null;
 
         SuperLyricWord[] result = new SuperLyricWord[syllables.size()];
         int cursor = 0;
+        long previousEnd = lineStart;
         for (int i = 0; i < syllables.size(); i++) {
             Syllable syllable = syllables.get(i);
             int count = syllable.count;
-            if (count <= 0 || cursor + count > text.length()) {
+            int nextCursor;
+            if (count <= 0 || count > text.length() - cursor) {
+                return null;
+            }
+            nextCursor = cursor + count;
+            if (syllable.startTimeMs < previousEnd || syllable.endTimeMs <= syllable.startTimeMs
+                || syllable.startTimeMs < lineStart || syllable.endTimeMs > lineEnd) {
                 return null;
             }
             result[i] = new SuperLyricWord(
-                text.substring(cursor, cursor + count),
+                text.substring(cursor, nextCursor),
                 syllable.startTimeMs,
                 syllable.endTimeMs
             );
-            cursor += count;
+            cursor = nextCursor;
+            previousEnd = syllable.endTimeMs;
         }
         return cursor == text.length() ? result : null;
     }
@@ -520,6 +676,34 @@ public final class SpotifyLyricAnalysis {
     /**
      * 无歌词异常：接口 404 时抛出，视为无歌词（不发任何 lyric）。
      */
+    public static final class OversizeException extends IOException {
+        OversizeException(int maxBytes) {
+            super("Spotify lyric response exceeds " + maxBytes + " bytes");
+        }
+    }
+
+    public static final class HttpStatusException extends IOException {
+        public final int code;
+        public final boolean retryable;
+
+        HttpStatusException(int code, boolean retryable) {
+            super("Spotify HTTP " + code);
+            this.code = code;
+            this.retryable = retryable;
+        }
+    }
+
+    public static final class AuthenticationException extends IOException {
+        public final int code;
+        public final long generation;
+
+        AuthenticationException(int code, long generation) {
+            super("Spotify authentication failed: HTTP " + code);
+            this.code = code;
+            this.generation = generation;
+        }
+    }
+
     public static final class NoFoundLyricException extends RuntimeException {
         @NonNull
         public final String id;

--- a/app/src/main/java/com/hchen/superlyric/utils/LyricCacheStore.java
+++ b/app/src/main/java/com/hchen/superlyric/utils/LyricCacheStore.java
@@ -30,8 +30,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -49,7 +53,15 @@ public final class LyricCacheStore {
     private static final String TAG = "LyricCacheStore";
     private static final String CACHE_ROOT = "superlyric" + File.separator + "lyric";
     private static final int CACHE_VERSION = 1;
-    private static final String VERSION_MARKER = "{\"v\":1,\"d\":";
+    private static final long MAX_PROVIDER_BYTES = 32L * 1024L * 1024L;
+    private static final int MAX_PROVIDER_FILES = 256;
+    private static final long MAX_CACHE_AGE_MS = 30L * 24L * 60L * 60L * 1000L;
+    private static final long TEMP_MAX_AGE_MS = 24L * 60L * 60L * 1000L;
+    /** 单个歌词原始响应上限；正常歌词响应远低于此值。 */
+    public static final int MAX_PAYLOAD_BYTES = 2 * 1024 * 1024;
+    private static final byte[] VERSION_PREFIX = ("{\"v\":" + CACHE_VERSION + ",\"d\":")
+        .getBytes(StandardCharsets.UTF_8);
+    private static final String[] ONLINE_PROVIDERS = {"Netease", "Hihonor", "Spotify"};
     private static final Pattern SAFE_SEGMENT = Pattern.compile("[A-Za-z0-9._-]+");
     private static final Pattern SAFE_KEY = Pattern.compile("[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*");
     /**
@@ -88,6 +100,10 @@ public final class LyricCacheStore {
      * @param data     接口返回的原始响应字节
      */
     public static void put(@Nullable Context context, @NonNull String provider, @NonNull String key, @NonNull byte[] data) {
+        if (data.length == 0 || data.length > MAX_PAYLOAD_BYTES) {
+            XposedLog.logW(TAG, "Reject lyric cache payload: provider=" + provider + ", bytes=" + data.length);
+            return;
+        }
         Context ctx = resolveContext(context);
         if (ctx == null) return;
 
@@ -99,25 +115,30 @@ public final class LyricCacheStore {
                 try {
                     Files.delete(file.toPath());
                 } catch (IOException e) {
-                    XposedLog.logW(TAG, "Failed to migrate old cache: " + file.getAbsolutePath(), e);
+                    XposedLog.logW(TAG, "Failed to migrate old lyric cache", e);
                 }
             }
+            File temp = null;
             try {
                 File parent = file.getParentFile();
                 if (parent != null && !parent.exists() && !parent.mkdirs()) {
                     return;
                 }
-                // 先写临时文件再原子替换：避免进程被杀时留下半截 JSON，缓存只读到完整内容
-                File temp = parent != null
-                    ? new File(parent, file.getName() + ".tmp")
-                    : new File(file.getName() + ".tmp");
-                byte[] framed = wrap(data);
-                Files.write(temp.toPath(), framed);
-                Files.move(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            } catch (IOException e) {
-                XposedLog.logW(TAG, "Failed to write lyric cache: " + file.getAbsolutePath(), e);
-            } catch (Throwable t) {
-                XposedLog.logW(TAG, "Failed to write lyric cache: " + file.getAbsolutePath(), t);
+                temp = File.createTempFile(file.getName() + ".", ".tmp", parent);
+                Files.write(temp.toPath(), wrap(data));
+                try {
+                    Files.move(temp.toPath(), file.toPath(),
+                        StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+                } catch (AtomicMoveNotSupportedException e) {
+                    Files.move(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
+                pruneProviderLocked(ctx, provider);
+            } catch (IOException | SecurityException e) {
+                XposedLog.logW(TAG, "Failed to write lyric cache", e);
+            } finally {
+                if (temp != null && temp.exists()) {
+                    deleteCachePath(temp);
+                }
             }
         }
     }
@@ -127,12 +148,11 @@ public final class LyricCacheStore {
      */
     @NonNull
     private static byte[] wrap(@NonNull byte[] data) {
-        byte[] prefix = VERSION_MARKER.getBytes(StandardCharsets.UTF_8);
         byte[] suffix = new byte[]{'}'};
-        byte[] framed = new byte[prefix.length + data.length + suffix.length];
-        System.arraycopy(prefix, 0, framed, 0, prefix.length);
-        System.arraycopy(data, 0, framed, prefix.length, data.length);
-        System.arraycopy(suffix, 0, framed, prefix.length + data.length, suffix.length);
+        byte[] framed = new byte[VERSION_PREFIX.length + data.length + suffix.length];
+        System.arraycopy(VERSION_PREFIX, 0, framed, 0, VERSION_PREFIX.length);
+        System.arraycopy(data, 0, framed, VERSION_PREFIX.length, data.length);
+        System.arraycopy(suffix, 0, framed, VERSION_PREFIX.length + data.length, suffix.length);
         return framed;
     }
 
@@ -142,10 +162,10 @@ public final class LyricCacheStore {
     @Nullable
     private static byte[] unpack(@NonNull byte[] data) {
         int len = data.length;
-        int head = VERSION_MARKER.length();
-        if (len <= head + 1) return null;
+        int head = VERSION_PREFIX.length;
+        if (len <= head + 1 || len > head + MAX_PAYLOAD_BYTES + 1) return null;
         for (int i = 0; i < head; i++) {
-            if (data[i] != VERSION_MARKER.getBytes(StandardCharsets.UTF_8)[i]) return null;
+            if (data[i] != VERSION_PREFIX[i]) return null;
         }
         if (data[len - 1] != '}') return null;
         return Arrays.copyOfRange(data, head, len - 1);
@@ -155,13 +175,18 @@ public final class LyricCacheStore {
      * 文件是否为当前版本格式（内容合法且带 v 字段）。
      */
     private static boolean hasVersion(@NonNull File file) {
-        byte[] data;
+        if (!isReadableCacheSize(file)) return false;
         try {
-            data = Files.readAllBytes(file.toPath());
-        } catch (IOException e) {
+            return unpack(Files.readAllBytes(file.toPath())) != null;
+        } catch (IOException | SecurityException e) {
             return false;
         }
-        return unpack(data) != null;
+    }
+
+    private static boolean isReadableCacheSize(@NonNull File file) {
+        long length = file.length();
+        return length > VERSION_PREFIX.length + 1L
+            && length <= VERSION_PREFIX.length + MAX_PAYLOAD_BYTES + 1L;
     }
 
     /**
@@ -183,18 +208,22 @@ public final class LyricCacheStore {
 
         File file = getFile(ctx, provider, key);
         if (file == null || !file.isFile()) return null;
-        try {
-            byte[] data = Files.readAllBytes(file.toPath());
-            byte[] payload = unpack(data);
-            // 旧格式（无 v 字段）或损坏内容：删除并视为未命中，由调用方回退网络
-            if (payload == null) {
-                Files.delete(file.toPath());
+        synchronized (WRITE_LOCK) {
+            try {
+                if (!isReadableCacheSize(file)) {
+                    Files.deleteIfExists(file.toPath());
+                    return null;
+                }
+                byte[] payload = unpack(Files.readAllBytes(file.toPath()));
+                if (payload == null) {
+                    Files.deleteIfExists(file.toPath());
+                    return null;
+                }
+                return payload;
+            } catch (IOException | SecurityException e) {
+                XposedLog.logW(TAG, "Failed to read lyric cache", e);
                 return null;
             }
-            return payload;
-        } catch (IOException e) {
-            XposedLog.logW(TAG, "Failed to read lyric cache: " + file.getAbsolutePath(), e);
-            return null;
         }
     }
 
@@ -206,34 +235,149 @@ public final class LyricCacheStore {
         if (ctx == null) return;
 
         File file = getFile(ctx, provider, key);
-        if (file == null || !file.isFile()) return;
-        try {
-            Files.delete(file.toPath());
-        } catch (IOException e) {
-            XposedLog.logW(TAG, "Failed to delete lyric cache: " + file.getAbsolutePath(), e);
+        if (file == null) return;
+        synchronized (WRITE_LOCK) {
+            try {
+                Files.deleteIfExists(file.toPath());
+            } catch (IOException | SecurityException e) {
+                XposedLog.logW(TAG, "Failed to delete lyric cache", e);
+            }
+        }
+    }
+
+    private static void pruneProviderLocked(@NonNull Context context, @NonNull String provider) {
+        String providerDir = sanitizeSegment(provider);
+        if (providerDir == null) return;
+        File root = new File(new File(context.getCacheDir(), CACHE_ROOT), providerDir);
+        if (!root.isDirectory() || hasSymbolicLinkBetween(root, context.getCacheDir())) return;
+
+        List<File> cacheFiles = new ArrayList<>();
+        collectCacheFiles(root, cacheFiles);
+        long now = System.currentTimeMillis();
+        for (File file : new ArrayList<>(cacheFiles)) {
+            long age = now - file.lastModified();
+            long maxAge = file.getName().endsWith(".tmp") ? TEMP_MAX_AGE_MS : MAX_CACHE_AGE_MS;
+            if (age > maxAge && deleteCachePath(file)) cacheFiles.remove(file);
+        }
+        cacheFiles.removeIf(file -> !file.isFile() || file.getName().endsWith(".tmp"));
+        cacheFiles.sort(Comparator.comparingLong(File::lastModified));
+        long total = 0L;
+        for (File file : cacheFiles) {
+            long length = Math.max(0L, file.length());
+            total = length > Long.MAX_VALUE - total ? Long.MAX_VALUE : total + length;
+        }
+        int remainingFiles = cacheFiles.size();
+        int index = 0;
+        while ((remainingFiles > MAX_PROVIDER_FILES || total > MAX_PROVIDER_BYTES)
+            && index < cacheFiles.size()) {
+            File file = cacheFiles.get(index++);
+            long length = Math.max(0L, file.length());
+            if (deleteCachePath(file)) {
+                remainingFiles--;
+                total = Math.max(0L, total - length);
+            }
+        }
+    }
+
+    private static void collectCacheFiles(@NonNull File directory, @NonNull List<File> result) {
+        File[] children = directory.listFiles();
+        if (children == null) return;
+        for (File child : children) {
+            if (Files.isSymbolicLink(child.toPath())) continue;
+            if (child.isDirectory()) collectCacheFiles(child, result);
+            else if (child.isFile() && (child.getName().endsWith(".json") || child.getName().endsWith(".tmp"))) {
+                result.add(child);
+            }
         }
     }
 
     /**
-     * 清空指定提供者的全部缓存文件（保留目录），用于版本升级后的整体失效。
+     * 清空全部在线歌词提供者的缓存命名空间。
+     *
+     * @param context 宿主 Context；为 {@code null} 时尝试解析当前 Application
+     * @return 所有提供者均清理成功时返回 {@code true}；Context 不可用、路径非法或任一项删除失败时返回 {@code false}
      */
-    public static void clearProviderCache(@Nullable Context context, @NonNull String provider) {
+    public static boolean clearOnlineProviderCaches(@Nullable Context context) {
         Context ctx = resolveContext(context);
-        if (ctx == null) return;
+        if (ctx == null) return false;
 
-        String providerDir = sanitizeSegment(provider);
-        if (providerDir == null) return;
-        File dir = new File(new File(ctx.getCacheDir(), CACHE_ROOT), providerDir);
-        File[] files = dir.listFiles();
-        if (files == null) return;
-        for (File file : files) {
-            if (file.isFile() && file.getName().endsWith(".json")) {
-                try {
-                    Files.delete(file.toPath());
-                } catch (IOException e) {
-                    XposedLog.logW(TAG, "Failed to clear lyric cache: " + file.getAbsolutePath(), e);
+        boolean success = true;
+        synchronized (WRITE_LOCK) {
+            for (String provider : ONLINE_PROVIDERS) {
+                if (!clearProviderCacheLocked(ctx, provider)) {
+                    success = false;
                 }
             }
+        }
+        return success;
+    }
+
+    /**
+     * 递归清空指定提供者的缓存命名空间，用于版本升级后的整体失效。
+     * 删除范围严格限制在合法 provider 目录内，不跟随符号链接。
+     *
+     * @param context  宿主 Context；为 {@code null} 时尝试解析当前 Application
+     * @param provider 提供者命名空间
+     * @return 命名空间不存在或全部内容删除成功时返回 {@code true}
+     */
+    public static boolean clearProviderCache(@Nullable Context context, @NonNull String provider) {
+        Context ctx = resolveContext(context);
+        if (ctx == null) return false;
+
+        synchronized (WRITE_LOCK) {
+            return clearProviderCacheLocked(ctx, provider);
+        }
+    }
+
+    private static boolean clearProviderCacheLocked(@NonNull Context context, @NonNull String provider) {
+        String providerDir = sanitizeSegment(provider);
+        if (providerDir == null) return false;
+
+        File cacheDir = context.getCacheDir();
+        File root = new File(cacheDir, CACHE_ROOT);
+        if (hasSymbolicLinkBetween(root, cacheDir)) return false;
+        File dir = new File(root, providerDir);
+        if (!dir.exists()) return true;
+        if (hasSymbolicLinkBetween(dir, cacheDir)) {
+            return Files.isSymbolicLink(dir.toPath()) && deleteCachePath(dir);
+        }
+        if (!dir.isDirectory()) {
+            return deleteCachePath(dir);
+        }
+        return deleteCacheTree(dir, true);
+    }
+
+    private static boolean deleteCacheTree(@NonNull File file, boolean keepRoot) {
+        if (Files.isSymbolicLink(file.toPath())) {
+            return deleteCachePath(file);
+        }
+
+        boolean success = true;
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children == null) {
+                XposedLog.logW(TAG, "Failed to list lyric cache directory");
+                return false;
+            }
+            for (File child : children) {
+                if (!deleteCacheTree(child, false)) {
+                    success = false;
+                }
+            }
+        }
+        if (!keepRoot && !deleteCachePath(file)) {
+            success = false;
+        }
+        return success;
+    }
+
+    private static boolean deleteCachePath(@NonNull File file) {
+        try {
+            Files.deleteIfExists(file.toPath());
+            return true;
+        } catch (IOException | SecurityException e) {
+            XposedLog.logW(TAG, "Failed to clear lyric cache", e);
+            return false;
         }
     }
 
@@ -246,10 +390,42 @@ public final class LyricCacheStore {
         String keyPath = sanitizeKey(key);
         if (providerDir == null || keyPath == null) return null;
 
-        return new File(
+        File file = new File(
             new File(context.getCacheDir(), CACHE_ROOT),
             providerDir + File.separator + keyPath + ".json"
         );
+        return isSafeCachePath(context, providerDir, file) ? file : null;
+    }
+
+    private static boolean hasSymbolicLinkBetween(@NonNull File path, @NonNull File boundary) {
+        File current = path;
+        while (current != null && !current.equals(boundary)) {
+            if (current.exists() && Files.isSymbolicLink(current.toPath())) return true;
+            current = current.getParentFile();
+        }
+        return current == null;
+    }
+
+    private static boolean isSafeCachePath(@NonNull Context context, @NonNull String provider,
+                                           @NonNull File target) {
+        try {
+            File rootPath = new File(context.getCacheDir(), CACHE_ROOT);
+            if (rootPath.exists() && Files.isSymbolicLink(rootPath.toPath())) return false;
+            File root = rootPath.getCanonicalFile();
+            File providerRoot = new File(root, provider).getCanonicalFile();
+            File canonicalTarget = target.getCanonicalFile();
+            String prefix = providerRoot.getPath() + File.separator;
+            if (!canonicalTarget.getPath().startsWith(prefix)) return false;
+
+            File current = target.getParentFile();
+            while (current != null && !current.equals(root)) {
+                if (current.exists() && Files.isSymbolicLink(current.toPath())) return false;
+                current = current.getParentFile();
+            }
+            return current != null;
+        } catch (IOException | SecurityException e) {
+            return false;
+        }
     }
 
     /**
@@ -275,6 +451,7 @@ public final class LyricCacheStore {
      */
     @Nullable
     private static String sanitizeSegment(@NonNull String segment) {
+        if (segment.equals(".") || segment.equals("..")) return null;
         return SAFE_SEGMENT.matcher(segment).matches() ? segment : null;
     }
 


### PR DESCRIPTION
- isolate Spotify and Netease requests by track generation
- bound response parsing, retries, and authentication recovery
- make lyric cache migration, pruning, and writes safer
- prevent stale hooks and malformed timelines from leaking state