### PR TITLE
fix: adapt SaltMusic hook to Salt Player 12.2.x

### DIFF
--- a/app/src/main/java/com/hchen/superlyric/hook/AbsPublisher.java
+++ b/app/src/main/java/com/hchen/superlyric/hook/AbsPublisher.java
@@ -154,6 +154,7 @@ public abstract class AbsPublisher extends AbsModule {
     }
 
     public static void sendLyric(@NonNull SuperLyricData data) {
+        ensurePublisherRegistered();
         SuperLyricHelper.sendLyric(data);
     }
 
@@ -163,8 +164,25 @@ public abstract class AbsPublisher extends AbsModule {
 
     public static void sendStop(@NonNull SuperLyricData data) {
         synchronized (sPublishLock) {
+            ensurePublisherRegistered();
             SuperLyricHelper.sendStop(data);
             sLastLyric = null;
+        }
+    }
+
+    /**
+     * 确保当前进程已注册为发布者（publisher）。
+     * <p>
+     * hooktool 3.2.1 的 Application 生命周期钩子带 processName 匹配检查，
+     * 在部分音乐应用（如椒盐音乐 12.2.x）上 onApplicationCreated 可能不会触发，
+     * 导致发布者从未注册、歌词发送被拒。这里在每次发送前兜底注册。
+     */
+    private static void ensurePublisherRegistered() {
+        try {
+            if (!SuperLyricHelper.isPublisherRegistered()) {
+                SuperLyricHelper.registerPublisher();
+            }
+        } catch (Throwable ignored) {
         }
     }
 }

--- a/app/src/main/java/com/hchen/superlyric/hook/music/offline/SaltMusic.java
+++ b/app/src/main/java/com/hchen/superlyric/hook/music/offline/SaltMusic.java
@@ -28,6 +28,7 @@ import com.hchen.hooktool.hook.AbsHook;
 import com.hchen.processor.HookThis;
 import com.hchen.superlyric.hook.AbsPublisher;
 import com.hchen.superlyricapi.SuperLyricData;
+import com.hchen.superlyricapi.SuperLyricHelper;
 import com.hchen.superlyricapi.SuperLyricLine;
 import com.hchen.superlyricapi.SuperLyricWord;
 
@@ -127,14 +128,6 @@ public final class SaltMusic extends AbsPublisher {
                 ).single();
             }
         });
-        Field typeField = Arrays.stream(runMethod.getDeclaringClass().getDeclaredFields())
-            .filter(new Predicate<Field>() {
-                @Override
-                public boolean test(Field field) {
-                    return Objects.equals(field.getType(), int.class);
-                }
-            }).findFirst().orElseThrow();
-
         Field objectField = Arrays.stream(runMethod.getDeclaringClass().getDeclaredFields())
             .filter(new Predicate<Field>() {
                 @Override
@@ -143,17 +136,23 @@ public final class SaltMusic extends AbsPublisher {
                 }
             }).findFirst().orElseThrow();
 
-        Objects.requireNonNull(typeField);
         Objects.requireNonNull(objectField);
 
-        Field[] songFields = Arrays.stream(findClass("com.salt.music.service.MusicController").getDeclaredFields()).filter(
-            new Predicate<Field>() {
-                @Override
-                public boolean test(Field field) {
-                    return Objects.equals(field.getType(), findClass("kotlinx.coroutines.flow.MutableStateFlow"));
+        Field[] tmpSongFields = new Field[0];
+        try {
+            tmpSongFields = Arrays.stream(findClass("com.salt.music.service.MusicController").getDeclaredFields()).filter(
+                new Predicate<Field>() {
+                    @Override
+                    public boolean test(Field field) {
+                        return Objects.equals(field.getType(), findClass("kotlinx.coroutines.flow.MutableStateFlow"));
+                    }
                 }
-            }
-        ).toArray(Field[]::new);
+            ).toArray(Field[]::new);
+        } catch (Throwable t) {
+            // 新版椒盐音乐可能移除/改写了 MusicController 的字段类型，
+            // 歌曲信息（标题/歌手/专辑）缺失不影响歌词本身的获取。
+        }
+        final Field[] songFields = tmpSongFields;
         final Field[] songFieldsArr = {null};
 
         hook(runMethod, new AbsHook() {
@@ -163,12 +162,10 @@ public final class SaltMusic extends AbsPublisher {
                         return;
                     }
 
-                    int type = (int) getField(typeField, getThisObject());
-                    if (type == 21) {
-                        Object lyricData = getField(objectField, getThisObject());
-                        if (lyricData == null) {
-                            return;
-                        }
+                    Object lyricData = getField(objectField, getThisObject());
+                    if (lyricData == null || !lyricsClass.isInstance(lyricData)) {
+                        return;
+                    }
 
                         if (songFieldsArr[0] == null) {
                             for (Field s : songFields) {
@@ -246,10 +243,17 @@ public final class SaltMusic extends AbsPublisher {
                                 .setLyric(new SuperLyricLine(sb.toString(), words, delay))
                                 .setTranslation(new SuperLyricLine(Optional.ofNullable(translation).orElse(""))));
                         }
-                    }
                 }
             }
         );
+
+        // 主动注册发布者：hooktool 3.2.1 的 onApplicationCreated 在部分应用上
+        // 不会触发（processName 匹配问题），这里在 Hook 就绪后提前注册，
+        // 确保歌词能正常发布。失败不影响后续（发送前还会兜底重试）。
+        try {
+            SuperLyricHelper.registerPublisher();
+        } catch (Throwable ignored) {
+        }
     }
 
     private record LyricData(long startTime, long endTime, String lyric) {


### PR DESCRIPTION
## 问题

椒盐音乐（Salt Player）12.2.x 更新后，SuperLyric 无法获取歌词（见 issue #46）。经反编译 12.2.1 分析，原因有三：

1. **歌词回调 type 值随版本变化**：12.1.x 是 21，12.2.0 是 20，12.2.1 是 19。原来硬编码检查 `type == 21` 导致新版失效。
2. **`kotlinx.coroutines.flow.MutableStateFlow` 被移除**：12.2.x 不再包含该类，`findClass` 抛 `NoClassDefFoundError`，导致 `onPackageReady` 崩溃、歌词 Hook 从未注册。
3. **publisher 注册可能不触发**：hooktool 3.2.1 的 Application 生命周期钩子带 processName 匹配检查，部分应用（含椒盐 12.2.x）上 `onApplicationCreated` 不会触发，导致发布者从未注册、歌词发送被拒。

## 修复

- **SaltMusic.java**：
  - 用**类型判断**（`lyricsClass.isInstance(lyricData)`）替代硬编码的 type 检查，兼容所有版本的椒盐音乐；
  - `MusicController` 字段查找加 try-catch 容错，找不到 `MutableStateFlow` 时跳过歌曲信息（不影响歌词获取）；
  - Hook 就绪后主动注册 publisher。
- **AbsPublisher.java**：每次发送歌词前自动检查并补注册 publisher。

## 测试

已在小米（Android 16, KernelSU + LSPosed 2.1.1）上实测：椒盐音乐 12.2.1 + 修复版，歌词可正常获取并发布（超级岛歌词显示正常）。